### PR TITLE
Update Palworld Startup Argument

### DIFF
--- a/Palworld.cs/Palworld.cs
+++ b/Palworld.cs/Palworld.cs
@@ -19,7 +19,7 @@ namespace WindowsGSM.Plugins
             name = "WindowsGSM.Palworld", // WindowsGSM.XXXX
             author = "ohmcodes",
             description = "WindowsGSM plugin for supporting Palworld Dedicated Server",
-            version = "1.1.2",
+            version = "1.1.3",
             url = "https://github.com/ohmcodes/WindowsGSM.Palworld", // Github repository link (Best practice)
             color = "#1E8449" // Color Hex
         };
@@ -46,7 +46,7 @@ namespace WindowsGSM.Plugins
         public string Maxplayers = "32"; // WGSM reads this as string but originally it is number or int (MaxPlayers)
         public string Port = "8211"; // WGSM reads this as string but originally it is number or int
         public string QueryPort = "8212"; // WGSM reads this as string but originally it is number or int (SteamQueryPort)
-        public string Additional = "EpicApp=PalServer -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS";
+        public string Additional = "-publiclobby -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS -rcon";
 
 
         private Dictionary<string, string> configData = new Dictionary<string, string>();

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@
 
 ### Available Params
 All these params are automatically set by WGSM
-- EpicApp=PalServer	            Setup server as a community server. Do not change this parameter.
+- -publiclobby   	            Setup server as a community server. Do not change this parameter.
 - -publicip=192.168.xxx.xxx     Usualy the local port of the server (Change via WGSM settings)
 - -publicport=8211              cant be change and its not really working (Change via WGSM settings)
 - -port=8211                    can be change and working (Change via WGSM settings)


### PR DESCRIPTION
`EpicApp=PalServer` was deprecated with the recent 1.5 release and replaced with `-publiclobby`. This can be seen on the [Palword Tech](https://tech.palworldgame.com/settings-and-operation/arguments/) website.

Some users have issue with RCON being enabled by default so the `-rcon` flag was added to make it functions properly.