### PR TITLE
StartPath and Logging

### DIFF
--- a/Palworld.cs/Palworld.cs
+++ b/Palworld.cs/Palworld.cs
@@ -34,7 +34,7 @@ namespace WindowsGSM.Plugins
         public override string AppId => "2394010"; /* taken via https://steamdb.info/app/2394010/info/ */
 
         // - Game server Fixed variables
-        public override string StartPath => @"Pal\Binaries\Win64\PalServer-Win64-Test-Cmd.exe"; // Game server start path 
+        public override string StartPath => @"Pal\Binaries\Win64\PalServer-Win64-Shipping-Cmd.exe"; // Game server start path 
         public string FullName = "Palworld Dedicated Server"; // Game server FullName
         public bool AllowsEmbedConsole = true;  // Does this server support output redirect?
         public int PortIncrements = 1; // This tells WindowsGSM how many ports should skip after installation
@@ -46,7 +46,7 @@ namespace WindowsGSM.Plugins
         public string Maxplayers = "32"; // WGSM reads this as string but originally it is number or int (MaxPlayers)
         public string Port = "8211"; // WGSM reads this as string but originally it is number or int
         public string QueryPort = "8212"; // WGSM reads this as string but originally it is number or int (SteamQueryPort)
-        public string Additional = "-publiclobby -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS -rcon";
+        public string Additional = "-publiclobby -useperfthreads -NoAsyncLoadingThread -UseMultithreadForDS -rcon -logformat=text";
 
 
         private Dictionary<string, string> configData = new Dictionary<string, string>();


### PR DESCRIPTION
With the new Palworld update they changed a couple of things.
- They added a new startup flag that enables logging with `-logformat=text`.
- The game server start path has changed.
  - `Pal\Binaries\Win64\PalServer-Win64-Test-Cmd.exe` to `Pal\Binaries\Win64\PalServer-Win64-Shipping-Cmd.exe`

They also introduced a new rest api, but I haven't looked into it yet.